### PR TITLE
Feat/improve log

### DIFF
--- a/db/badgerdb.go
+++ b/db/badgerdb.go
@@ -27,7 +27,7 @@ func init() {
 	dbConstructor := func(dir string) (DB, error) {
 		return newBadgerDB(dir)
 	}
-	registorDBConstructor(BadgerImpl, dbConstructor)
+	registerDBConstructor(BadgerImpl, dbConstructor)
 }
 
 func (db *badgerDB) runBadgerGC() {
@@ -311,9 +311,9 @@ func (transaction *badgerTransaction) Discard() {
 	transaction.tx.Discard()
 }
 
-//=========================================================
+// =========================================================
 // Bulk Implementation
-//=========================================================
+// =========================================================
 type badgerBulk struct {
 	db        *badgerDB
 	bulk      *badger.WriteBatch

--- a/db/db.go
+++ b/db/db.go
@@ -6,49 +6,55 @@
 /*
 Package db is an wrapper of key-value database implementations. Currently, this supports badgerdb (https://github.com/dgraph-io/badger).
 
-Basic Usage
+# Basic Usage
 
 You can create database using a newdb func like this
- database := NewDB(BadgerImpl, "./test")
+
+	database := NewDB(BadgerImpl, "./test")
 
 A first argument is a backend db type to use, and a second is a root directory to store db files.
 After creating db, you can write, read or delete single key-value using funcs in DB interface.
- // write data
- database.Set([]byte("key"), []byte("val"))
 
- // read data
- read := Get([]byte("key"))
+	// write data
+	database.Set([]byte("key"), []byte("val"))
 
- // delete data
- database.Delete([]byte("key"))
+	// read data
+	read := Get([]byte("key"))
 
-Transaction
+	// delete data
+	database.Delete([]byte("key"))
+
+# Transaction
 
 A Transaction is a bulk set of operations to ensure atomic success or fail.
- // create a new transaction
- tx := database.NewTX(true)
 
- // reserve writing
- tx.Set([]byte("keyA"), []byte("valA"))
- tx.Set([]byte("keyB"), []byte("valB"))
+	// create a new transaction
+	tx := database.NewTX(true)
 
- // Get will return a value reserved to write in this transaction
- mustBeValA := tx.Get([]byte("keyA"))
+	// reserve writing
+	tx.Set([]byte("keyA"), []byte("valA"))
+	tx.Set([]byte("keyB"), []byte("valB"))
 
- // Perform writing
- tx.Commit()
+	// Get will return a value reserved to write in this transaction
+	mustBeValA := tx.Get([]byte("keyA"))
+
+	// Perform writing
+	tx.Commit()
+
 If you want to cancel and discard operations in tx, then you must call Discard() func to prevent a memory leack
- // If you create a tx, but do not commit, than you have to call this
- tx.Discard()
 
-Iterator
+	// If you create a tx, but do not commit, than you have to call this
+	tx.Discard()
+
+# Iterator
 
 An iteractor provides a way to get all keys sequentially.
- // create an iterator that covers all range
- for iter := database.Iterator(nil, nil); iter.Valid(); iter.Next() {
-	 // print each key-value pair
-	 fmt.Printf("%s = %s", string(iter.Key()), string(iter.Value()))
- }
+
+	 // create an iterator that covers all range
+	 for iter := database.Iterator(nil, nil); iter.Valid(); iter.Next() {
+		 // print each key-value pair
+		 fmt.Printf("%s = %s", string(iter.Key()), string(iter.Value()))
+	 }
 
 You can find more detail usages at a db_test.go file
 */
@@ -61,7 +67,7 @@ import (
 )
 
 var dbImpls = map[ImplType]dbConstructor{}
-var logger *extendedLog
+var logger *badgerExtendedLog
 
 func registorDBConstructor(dbimpl ImplType, constructor dbConstructor) {
 	dbImpls[dbimpl] = constructor
@@ -69,7 +75,8 @@ func registorDBConstructor(dbimpl ImplType, constructor dbConstructor) {
 
 // NewDB creates new database or load existing database in the directory
 func NewDB(dbimpltype ImplType, dir string) DB {
-	logger = &extendedLog{Logger: log.NewLogger("db")}
+	// The default wrapper need 3 frames and badger wrapper need 1 frame to show actual stack trace.
+	logger = &badgerExtendedLog{Logger: log.NewLogger("db").WithSkipFrameCount(4)}
 	db, err := dbImpls[dbimpltype](dir)
 
 	if err != nil {

--- a/db/db.go
+++ b/db/db.go
@@ -69,14 +69,14 @@ import (
 var dbImpls = map[ImplType]dbConstructor{}
 var logger *badgerExtendedLog
 
-func registorDBConstructor(dbimpl ImplType, constructor dbConstructor) {
+func registerDBConstructor(dbimpl ImplType, constructor dbConstructor) {
 	dbImpls[dbimpl] = constructor
 }
 
 // NewDB creates new database or load existing database in the directory
 func NewDB(dbimpltype ImplType, dir string) DB {
 	// The default wrapper need 3 frames and badger wrapper need 1 frame to show actual stack trace.
-	logger = &badgerExtendedLog{Logger: log.NewLogger("db").WithSkipFrameCount(4)}
+	logger = newBadgerExtendedLog(log.NewLogger("db"))
 	db, err := dbImpls[dbimpltype](dir)
 
 	if err != nil {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -141,7 +141,7 @@ func TestTransactionDelete(t *testing.T) {
 
 		tx.Commit()
 
-		// after commit, chekc the value from the db
+		// after commit, check the value from the db
 		assert.Equal(t, "", string(db.Get([]byte(tmpDbTestKey1))), db.Type())
 
 		db.Close()
@@ -151,6 +151,9 @@ func TestTransactionDelete(t *testing.T) {
 
 func TestTransactionCommitTwice(t *testing.T) {
 	for key := range dbImpls {
+		// TODO BadgerImpl fails to test since badger/v2 by bug. This bug was patched in v4.3.0 but we cannot update it unless more tests.
+		// see https://github.com/hypermodeinc/badger/pull/2018
+
 		dir, db := createTmpDB(key)
 
 		// create a new writable tx
@@ -160,7 +163,7 @@ func TestTransactionCommitTwice(t *testing.T) {
 		tx.Commit()
 
 		// a second commit will cause panic
-		assert.Panics(t, func() { tx.Commit() })
+		assert.Panics(t, func() { tx.Commit() }, "db impl "+key+" commit twice should panic")
 
 		db.Close()
 		os.RemoveAll(dir)

--- a/db/leveldb.go
+++ b/db/leveldb.go
@@ -21,7 +21,7 @@ func init() {
 	dbConstructor := func(dir string) (DB, error) {
 		return newLevelDB(dir)
 	}
-	registorDBConstructor(LevelImpl, dbConstructor)
+	registerDBConstructor(LevelImpl, dbConstructor)
 }
 
 func newLevelDB(dir string) (DB, error) {

--- a/db/logger.go
+++ b/db/logger.go
@@ -14,7 +14,7 @@ func newBadgerExtendedLog(logger *log.Logger) *badgerExtendedLog {
 		panic("base logger of raft is nil")
 	}
 
-	return &badgerExtendedLog{logger.WithSkipFrameCount(3)}
+	return &badgerExtendedLog{logger.WithSkipFrameCount(4)}
 }
 
 var _ badger.Logger = (*badgerExtendedLog)(nil)
@@ -34,4 +34,8 @@ func (l *badgerExtendedLog) Infof(f string, v ...interface{}) {
 
 func (l *badgerExtendedLog) Debugf(f string, v ...interface{}) {
 	l.Debug().Msgf(f, v...)
+}
+
+func (l *badgerExtendedLog) Tracef(f string, v ...interface{}) {
+	l.Trace().Msgf(f, v...)
 }

--- a/db/logger.go
+++ b/db/logger.go
@@ -5,25 +5,33 @@ import (
 	"github.com/dgraph-io/badger/v3"
 )
 
-type extendedLog struct {
+type badgerExtendedLog struct {
 	*log.Logger
 }
 
-var _ badger.Logger = (*extendedLog)(nil)
+func newBadgerExtendedLog(logger *log.Logger) *badgerExtendedLog {
+	if logger == nil {
+		panic("base logger of raft is nil")
+	}
 
-func (l *extendedLog) Errorf(f string, v ...interface{}) {
+	return &badgerExtendedLog{logger.WithSkipFrameCount(3)}
+}
+
+var _ badger.Logger = (*badgerExtendedLog)(nil)
+
+func (l *badgerExtendedLog) Errorf(f string, v ...interface{}) {
 	l.Error().Msgf(f, v...)
 }
 
-func (l *extendedLog) Warningf(f string, v ...interface{}) {
+func (l *badgerExtendedLog) Warningf(f string, v ...interface{}) {
 	l.Warn().Msgf(f, v...)
 }
 
-func (l *extendedLog) Infof(f string, v ...interface{}) {
+func (l *badgerExtendedLog) Infof(f string, v ...interface{}) {
 	// reduce info to debug level because infos at badgerdb are too detail
 	l.Debug().Msgf(f, v...) // INFO -> DEBUG
 }
 
-func (l *extendedLog) Debugf(f string, v ...interface{}) {
+func (l *badgerExtendedLog) Debugf(f string, v ...interface{}) {
 	l.Debug().Msgf(f, v...)
 }

--- a/db/memorydb.go
+++ b/db/memorydb.go
@@ -20,7 +20,7 @@ func init() {
 	dbConstructor := func(dir string) (DB, error) {
 		return newMemoryDB(dir)
 	}
-	registorDBConstructor(MemoryImpl, dbConstructor)
+	registerDBConstructor(MemoryImpl, dbConstructor)
 }
 
 func newMemoryDB(dir string) (DB, error) {

--- a/log/global.go
+++ b/log/global.go
@@ -1,0 +1,63 @@
+package log
+
+import (
+	"github.com/rs/zerolog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+)
+
+// SetRelativeLogPathForProject configures the log caller function to display paths relative to the project root.
+func SetRelativeLogPathForProject() {
+	SetRelativeLogPath(FindProjectRootWithSkip(1))
+}
+
+func SetRelativeLogPath(baseDir string) {
+	// customizing CallerMarshalFunc of zerolog
+	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
+		// find relative path based of project root
+		relPath, err := filepath.Rel(baseDir, file)
+		if err != nil {
+			// use original path if failed
+			relPath = file
+		}
+		return relPath + ":" + strconv.Itoa(line)
+	}
+}
+
+// FindProjectRoot finds project root of caller. It may only work in go module project.
+func FindProjectRoot() string {
+	return FindProjectRootWithSkip(1)
+}
+
+func FindProjectRootWithSkip(skip int) string {
+	var skipCount = skip + 1
+	_, file, _, ok := runtime.Caller(skipCount)
+	if !ok {
+		return ""
+	}
+	return findProjectRoot(file)
+}
+
+func findProjectRoot(startPath string) string {
+	dir := filepath.Dir(startPath)
+	for {
+		// find root directory
+		if fileExists(filepath.Join(dir, "go.mod")) {
+			// Assuming path containing go.mod as a project root.
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // finish scan for system root
+		}
+		dir = parent
+	}
+	return dir // return current directory if scan was failed
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -1,0 +1,21 @@
+package log
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFindProjectRoot(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		// TODO: Add test cases.
+		{"base", "/Users/sg31park/Developer/aergo/aergo-lib"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, FindProjectRoot(), "FindProjectRoot()")
+		})
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -67,6 +67,8 @@ var defaultConfFileName = "arglog"
 
 var defaultConfStr = ""
 
+var enableCaller = false
+
 func loadConfigFile() *viper.Viper {
 	// init viper
 	viperConf.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
@@ -154,9 +156,9 @@ func initLog() {
 			baseLogger = baseLogger.Output(out)
 		}
 	}
-
+	enableCaller = viperConf.GetBool("caller")
 	// set a caller print option
-	if viperConf.GetBool("caller") {
+	if enableCaller {
 		baseLogger = baseLogger.With().Caller().Logger()
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -9,34 +9,34 @@ Package log is a global and configurable logger pkg, based on zerolog (https://g
 You can congifure this logger using a toml configuration file. Here is an example configuration that has all available fields.
 However fields are optional. Even if you don't set some of them, logger will work well with a default value.
 
- # A default log level for all sub modules
- # must be one of this; debug/info/warn/error/fatal/panic
- level = "info"
+	# A default log level for all sub modules
+	# must be one of this; debug/info/warn/error/fatal/panic
+	level = "info"
 
- # A log output formatter
- # can be chosen among this; console, console_no_color, json
- formatter = "json"
+	# A log output formatter
+	# can be chosen among this; console, console_no_color, json
+	formatter = "json"
 
- # Enabling source file and line printer
- caller = false
+	# Enabling source file and line printer
+	caller = false
 
- # A time stamp field format.
- # e.g. in a time/format.go file
- # ANSIC       = "Mon Jan _2 15:04:05 2006"
- # RFC822      = "02 Jan 06 15:04 MST"
- # RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
- # Kitchen     = "3:04PM"
- # Stamp       = "Jan _2 15:04:05"
- timefieldformat = "3:04 PM"
+	# A time stamp field format.
+	# e.g. in a time/format.go file
+	# ANSIC       = "Mon Jan _2 15:04:05 2006"
+	# RFC822      = "02 Jan 06 15:04 MST"
+	# RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
+	# Kitchen     = "3:04PM"
+	# Stamp       = "Jan _2 15:04:05"
+	timefieldformat = "3:04 PM"
 
- # If there is a sub module and it has deferent options from defaults,
- # sub modules can be configed using a map struct of toml
- # currently, only setting sub modules's level is allowed
- [sub_module_name]
- level = "error"
+	# If there is a sub module and it has deferent options from defaults,
+	# sub modules can be configed using a map struct of toml
+	# currently, only setting sub modules's level is allowed
+	[sub_module_name]
+	level = "error"
 
- [can_have_multiple_module]
- level = "debug"
+	[can_have_multiple_module]
+	level = "debug"
 
 After creating a log configuration file, you must locate that to a same directory where binary file is.
 Or you can register the config file path at an environment variable 'arglib_logconfig'.
@@ -161,18 +161,7 @@ func initLog() {
 	}
 
 	// set a base log level
-	level := viperConf.GetString("level")
-	var zLevel zerolog.Level
-	if level == "" {
-		zLevel = zerolog.InfoLevel
-	} else {
-		var err error
-		if zLevel, err = zerolog.ParseLevel(level); err != nil {
-			baseLogger.Warn().Err(err).Msg("Fail to parse and set a default log level. set the level as info")
-			zLevel = zerolog.InfoLevel
-		}
-	}
-
+	var zLevel = getLogLevel(viperConf)
 	// create logger by attaching a timestamp and setting a level
 	baseLogger = baseLogger.With().Timestamp().Logger().Level(zLevel)
 	baseLevel = zLevel
@@ -192,13 +181,21 @@ func NewLogger(moduleName string) *Logger {
 		isLogInit = true
 	}
 
+	subViperConf := viperConf.Sub(moduleName)
 	// create sub logger
+	zLevel := getLogLevel(subViperConf)
+	zLogger := createInternalLogger(subViperConf, moduleName, zLevel)
+
+	return &Logger{
+		Logger: &zLogger,
+		name:   moduleName,
+		level:  zLevel,
+	}
+}
+
+func createInternalLogger(subViperConf *viper.Viper, moduleName string, level zerolog.Level) zerolog.Logger {
 	zLogger := baseLogger.With().Str("module", moduleName).Logger()
 
-	// try to load sub config
-	var zLevel zerolog.Level
-	zLevel = baseLevel
-	subViperConf := viperConf.Sub(moduleName)
 	if subViperConf != nil {
 		outputName := subViperConf.GetString("out")
 		if outputName != "" {
@@ -209,24 +206,27 @@ func NewLogger(moduleName string) *Logger {
 			}
 		}
 
-		level := subViperConf.GetString("level")
-		var err error
+	}
 
+	zLogger = zLogger.Level(level)
+	return zLogger
+}
+
+func getLogLevel(conf *viper.Viper) zerolog.Level {
+	// try to load sub config
+	var zLevel = baseLevel
+
+	if conf != nil {
+		var err error
+		level := conf.GetString("level")
 		if level != "" {
 			if zLevel, err = zerolog.ParseLevel(level); err != nil {
 				zLevel = zerolog.InfoLevel
 			}
-
 			// set sub logger's level
-			zLogger = zLogger.Level(zLevel)
 		}
 	}
-
-	return &Logger{
-		Logger: &zLogger,
-		name:   moduleName,
-		level:  zLevel,
-	}
+	return zLevel
 }
 
 var errEmptyName = errors.New("not really error. just placeholder")
@@ -238,7 +238,8 @@ var errEmptyName = errors.New("not really error. just placeholder")
 // Note: There can be argument about thread safe, because Writer of os.File is not
 // guaranteed in thread safe golang runtime, also in stdout and stderr.
 // But it looks practically less dangerous in POSIX compatible system.
-//    https://stackoverflow.com/questions/29981050/concurrent-writing-to-a-file
+//
+//	https://stackoverflow.com/questions/29981050/concurrent-writing-to-a-file
 func getOutput(outName string) (*os.File, error) {
 	switch outName {
 	case "":
@@ -257,7 +258,7 @@ func getOutput(outName string) (*os.File, error) {
 	}
 }
 
-// Default returns a defulat logger. this logger does not have a module name.
+// Default returns a default logger. this logger does not have a module name.
 func Default() *Logger {
 	logInitLock.Lock()
 	defer logInitLock.Unlock()
@@ -286,7 +287,7 @@ func (logger *Logger) Level() string {
 	return logger.level.String()
 }
 
-// Logger keeps configrations, and provides a funcs to print logs.
+// Logger keeps configurations, and provides a functions to print logs.
 type Logger struct {
 	*zerolog.Logger
 	name  string

--- a/log/log_extension.go
+++ b/log/log_extension.go
@@ -3,10 +3,14 @@ package log
 // WithSkipFrameCount creates new logger with sets the number of frames to skip when determining the caller information in the logger output.
 // It is useful for log wrapper.
 func (logger *Logger) WithSkipFrameCount(skipFrameCount int) *Logger {
-	zLogger := logger.With().CallerWithSkipFrameCount(skipFrameCount).Logger()
-	return &Logger{
-		Logger: &zLogger,
-		name:   logger.name,
-		level:  logger.level,
+	if enableCaller {
+		zLogger := logger.With().CallerWithSkipFrameCount(skipFrameCount).Logger()
+		return &Logger{
+			Logger: &zLogger,
+			name:   logger.name,
+			level:  logger.level,
+		}
+	} else {
+		return logger
 	}
 }

--- a/log/log_extension.go
+++ b/log/log_extension.go
@@ -1,0 +1,12 @@
+package log
+
+// WithSkipFrameCount creates new logger with sets the number of frames to skip when determining the caller information in the logger output.
+// It is useful for log wrapper.
+func (logger *Logger) WithSkipFrameCount(skipFrameCount int) *Logger {
+	zLogger := logger.With().CallerWithSkipFrameCount(skipFrameCount).Logger()
+	return &Logger{
+		Logger: &zLogger,
+		name:   logger.name,
+		level:  logger.level,
+	}
+}


### PR DESCRIPTION
This PR expresses the location of log occurrence more neatly.
Logs in Aergo source are represented by shortest path of relative to the project root, and the badgerdb logs display the position of the actual source.

## before

```
2025-04-22T11:23:30.180 INF ../../../../Users/sg31park/Developer/aergo/aergo/cmd/aergosvr/aergosvr.go:99 > AERGO SVR STARTED branch=develop module=asvr revision=19fe8608
2025-04-22T11:23:30.189 INF ../../../../Users/sg31park/Developer/aergo/aergo/chain/chaindb.go:82 > chain database initialized datadir=/Volumes/MacExternal/blockchain/dpossingle/data/X7845 module=chain
2025-04-22T11:23:30.299 DBG ../../../../Users/sg31park/Developer/go/pkg/mod/github.com/aergoio/aergo-lib@v1.1.0/db/logger.go:24 > All 40 tables opened in 53ms
 module=db
```

## after
```
2025-04-22T11:48:54.998 INF cmd/aergosvr/aergosvr.go:101 > AERGO SVR STARTED branch=feat/improveLogging module=asvr revision=f601d791
2025-04-22T11:48:55.008 INF chain/chaindb.go:82 > chain database initialized datadir=/Volumes/MacExternal/blockchain/dpossingle/data/X7845 module=chain
2025-04-22T11:48:55.330 DBG ../badger/levels.go:171 > All 41 tables opened in 122ms
 module=db
```
